### PR TITLE
Task: CLI integration and browser output formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,22 @@ Response structure (playlists nested in program blocks):
 4. Duration filter: prefer tracks within +/- 10 seconds
 5. Popularity tiebreaker: pick most popular if multiple matches
 
+## CLI Flags
+
+Standard mode (API-based):
+- `--date/-d` - Required. Date to fetch playlist (YYYY-MM-DD)
+- `--start/-s` - Start time filter (HH:MM)
+- `--end/-e` - End time filter (HH:MM)
+- `--name/-n` - Playlist name (default: "KUTX YYYY-MM-DD")
+- `--preview/-p` - Preview mode (no playlist creation)
+- `--manual/-m` - Manual mode (output search links)
+- `--cached/-c` - Use cached KUTX data
+- `--resolve/-r` - Apply resolution (INDEX=CHOICE)
+
+Browser mode (Playwright-based):
+- `--browser/-b` - Use browser automation instead of Spotify API
+- `--login` - Force fresh Spotify login (with --browser)
+
 ## Conventions
 
 - Virtual environment: `~/venvs/kutx2spotify` (not .venv)


### PR DESCRIPTION
Closes #16

## Implementation Summary

Implements: #16
Epic: #12
Branch: epic/spotify-playwright/task-4

## Changes
- Added `--browser/-b` CLI flag to use Playwright instead of Spotify API
- Added `--login` CLI flag to force fresh Spotify login (with --browser)
- Added browser output functions:
  - `print_browser_header()` - Print header for browser mode
  - `print_browser_track_added()` - Print track addition result with reason and alternatives
  - `print_browser_track_skipped()` - Print when track addition failed
  - `print_browser_summary()` - Print browser mode summary
- Added `_run_browser_workflow()` async function to cli.py
- Integrated browser workflow into main() - if browser flag, run browser workflow
- Updated CLAUDE.md with new CLI flags documentation

## Quality Verification

- `just check-all` passing
- Coverage: 98.29%
- All acceptance criteria met

## Commits
- docs: Update documentation for #16 - add CLI flags section
- feat: Add browser mode CLI flags and output functions for #16
- test: Add comprehensive tests for browser CLI integration #16

## User Acceptance
- `--browser` flag triggers browser workflow
- `--login` forces fresh login
- Output shows each track with selection reason
- Alternatives shown for non-exact matches
- Summary shows added/skipped counts and playlist URL

## Next Steps
- Review and merge
- Close #16
- Update epic #12 checklist

---
Generated with Claude Code